### PR TITLE
parallelize on cluster with dask

### DIFF
--- a/jihong.ipynb
+++ b/jihong.ipynb
@@ -1,0 +1,147 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e4148126-4a21-411d-8e5d-60ee87dbe8da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask.distributed import Client\n",
+    "from dask_jobqueue import LSFCluster\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "669c3d62-3cfa-42e4-bb0a-2cc32eaa07bb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cluster = LSFCluster(project=\"genie\", cores=1, memory=\"30GB\", walltime=\"24:00\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8621e0b7-e27a-49ca-bfb2-2addc492121e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = Client(cluster)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bbf12c55-1bde-4c0e-94c3-fd43cd1ff724",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster.scale(jobs=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0d1ed1f7-f23f-4e84-adb9-089a1008b439",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def process_one_well(path_to_data, arg1, arg2):\n",
+    "    return arg1+arg2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0fc1a190-80fe-4bde-a897-c5b1328452d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raw_data = \"/groups/genie/genie/GECIScreenData/GECI_Imaging_Data\"\n",
+    "transfect = \"20191005_GCaMP96uf_analyzed\"\n",
+    "plate = \"P9a-20190930_GCaMP96uf\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "be0fdf0c-8515-41a2-8414-79304e72eb4f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wells = os.listdir(os.path.join(raw_data, transfect, plate, \"imaging\"))\n",
+    "wells = list(filter(lambda x: \"Well\" in x, wells))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "74c91fdd-a193-4c10-b8ea-db0bcb6a49fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "futures = []\n",
+    "for well in wells:\n",
+    "    future = client.submit(process_one_well, well, 3, 5)\n",
+    "    futures.append(future)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "4edd0c1d-7c6e-4d5f-994e-585e0b3143d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for future in futures:\n",
+    "    future.result()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "5d8a1bc8-59c4-4175-a199-73940341ef6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "6da34358-0852-4519-913f-594abe8e3519",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "GENIE",
+   "language": "python",
+   "name": "genie"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
if you click on the three horizontal does below "split / unified" and select "view file" then the code below in green will be displayed like a jupyter notebook.  should probably do this before merging.

to run this code on the cluster, use the jupyter notebook here:  https://jupyterhub.int.janelia.org/.  there are instructions there as to how to use your own conda environment.  you can also parallelize on your own workstation by changing `LSFCluster` to just `Cluster`.

adjust `cluster.scale(jobs=2)` to control how many wells you analyze simultaneously.

if analyzing each well requires more than 1 CPU core or more than 15GB RAM, increase `ncores` in this line:  `cluster = LSFCluster(project="genie", cores=1, memory="30GB", walltime="24:00")`.  similarly, if one well takes longer that 24 hours, increase `walltime`.  the `memory` kwarg is ignored, but must be present.

documentation for dask is here:  https://examples.dask.org/futures.html

let me know if/when you need some help getting this to work.  it can be a bit tricky.